### PR TITLE
Moonjelly Patch

### DIFF
--- a/Patches/Moonjelly Race/ThingDefs_Races/Moonjelly_Race.xml
+++ b/Patches/Moonjelly Race/ThingDefs_Races/Moonjelly_Race.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<operations>
+			<!--Search For the Moonjelly Race-->
+			<li Class ="PatchOperationFindMod">
+				<mods>
+					<li>Moonjelly Race</li>
+				</mods>
+				<match Class="PatchOperationSequence">
+					<operations>
+						
+						<!--Add the Humanoid Body Shape to the Moonjelly-->
+						<li Class="PatchOperationAddModExtension">
+							<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Moonjelly_Race"]</xpath>
+							<value>
+								<li Class="CombatExtended.RacePropertiesExtensionCE">
+									<bodyShape>Humanoid</bodyShape>
+								</li>
+							</value>
+						</li>
+						
+						<!--Add Stats to the Moonjelly-->
+						<li Class="PatchOperationAdd">
+							<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Moonjelly_Race"]/statBases</xpath>
+							<value>
+								<!--They aren't as good at range, have terrible meele, and are easily suppressed-->
+								<!--However, they reload quickly and are very reistant to smoke-->
+								<AimingAccuracy>0.9</AimingAccuracy>
+								<MeleeDodgeChance>0.9</MeleeDodgeChance>
+								<MeleeCritChance>0.8</MeleeCritChance>
+								<MeleeParryChance>0.7</MeleeParryChance>
+								<ReloadSpeed>1.3</ReloadSpeed>
+								<Suppressability>2.35</Suppressability>
+								<SmokeSensitivity>0.35</SmokeSensitivity>
+							</value>
+						</li>
+
+						<!--Give the Moon Gelly A toxic sting-->
+						<li Class="PatchOperationReplace">
+							<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Moonjelly_Race"]/tools</xpath>
+							<value>
+								<tools>
+									<li Class="CombatExtended.ToolCE">
+										<label>poison sting</label>
+										<capacities>
+											<li>Tentacletox</li>
+										</capacities>
+										<power>0.4</power>
+										<cooldownTime>0.8</cooldownTime>
+										<linkedBodyPartsGroup>Tentacles</linkedBodyPartsGroup>
+										<armorPenetration>0.09</armorPenetration>
+										<armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+									</li>
+								</tools>
+							</value>
+						</li>
+						
+						<!--Checks if the Race has comps and if they don't then it adds them-->
+						<li Class="PatchOperationSequence">
+							<success>Always</success>
+							<operations>
+								<li Class="PatchOperationTest">
+									<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Moonjelly_Race"]/comps</xpath>
+									<success>Invert</success>
+								</li>
+								<li Class="PatchOperationAdd">
+									<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Moonjelly_Race"]</xpath>
+									<value>
+										<comps />
+									</value>
+								</li>
+							</operations>
+						</li>
+
+						<!--Adds the suppresibility to the moonjellyies-->
+						<li Class="PatchOperationAdd">
+							<xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="Moonjelly_Race"]/comps</xpath>
+							<value>
+								<li>
+									<compClass>CombatExtended.CompPawnGizmo</compClass>
+								</li>
+								<li Class="CombatExtended.CompProperties_Suppressable" />
+							</value>
+						</li>
+
+					</operations>
+				</match>	
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Additions

- Patched the moonjelly race
- Good at medical, and are fast and good at reloading
- Suck at combat, are very easy to suppress, bad accuracy, and horrid melee
- Their melee attack can knock out creatures


## Reasoning

- I wanted Moonjellies to be compatabile

## Alternatives

- Moonjellies may need to have normal or higher smoke sensitivity, if smoke sensitivity does not refer to how much of smoke the pawn ignores when shooting

## Testing

- [x] Compiles without warnings
- [X] Game runs without errors
- [X] (For compatibility patches) ...with and without patched mod loaded
- [X] Playtested a colony (~10 hours)
